### PR TITLE
Add Docker support and AWS deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Deploy image to ECS
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SERVICE: ${{ secrets.ECS_SERVICE }}
+        run: |
+          aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" --force-new-deployment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for dacrew
+FROM python:3.11-slim
+
+# Ensure stdout/stderr from Python is unbuffered
+ENV PYTHONUNBUFFERED=1
+
+# Install dependencies
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Provide a default location for configuration. Users can mount their own
+# configuration file at /config/config.yml and override this path via the
+# DACREW_CONFIG environment variable.
+RUN mkdir -p /config
+ENV DACREW_CONFIG=/config/config.yml
+
+# Expose the application port
+EXPOSE 8000
+
+# Start the FastAPI server
+CMD ["uvicorn", "dacrew.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -43,3 +43,36 @@ A server application that evaluates Jira issues for their content quality using
 
 The agents defined here are placeholders; they demonstrate how CrewAI can be
 integrated and can be extended with real LLM prompts and embedding logic.
+
+## Branching model
+
+Development work should occur on feature branches cut from the `development`
+branch. The `main` branch is reserved for stable releases and is updated by
+rebasing from `development`. Pushing to `main` triggers the deployment
+workflow described below.
+
+## Running with Docker
+
+1. Build the container image:
+
+   ```bash
+   docker build -t dacrew .
+   ```
+
+2. Provide a configuration file and run the container:
+
+   ```bash
+   docker run -p 8000:8000 -v $(pwd)/config.yml:/config/config.yml dacrew
+   ```
+
+   The application reads its configuration from the path specified in the
+   `DACREW_CONFIG` environment variable, defaulting to `/config/config.yml`.
+
+## Continuous deployment
+
+GitHub Actions builds and pushes a Docker image to Amazon ECR whenever new
+commits reach `main`. The workflow then forces a new deployment of the
+configured ECS service. To enable this, define the following repository
+secrets: `AWS_ROLE_TO_ASSUME`, `AWS_REGION`, `ECR_REPOSITORY`, `ECS_CLUSTER`,
+and `ECS_SERVICE`.
+

--- a/dacrew/server.py
+++ b/dacrew/server.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import os
 from fastapi import FastAPI
 
 from .config import AppConfig
 from .service import EvaluationService
 
 
-def create_app(config_path: str = "config.yml") -> FastAPI:
-    """Create and configure the FastAPI application."""
+def create_app(config_path: str | None = None) -> FastAPI:
+    """Create and configure the FastAPI application.
 
-    cfg = AppConfig.load(config_path)
+    The configuration file path can be provided explicitly or through the
+    ``DACREW_CONFIG`` environment variable. If neither is supplied, the
+    application defaults to ``config.yml`` in the working directory.
+    """
+
+    path = config_path or os.environ.get("DACREW_CONFIG", "config.yml")
+    cfg = AppConfig.load(path)
     service = EvaluationService(cfg)
 
     app = FastAPI(title="dacrew")


### PR DESCRIPTION
## Summary
- allow server to load config from DACREW_CONFIG environment variable
- add Dockerfile to build runnable container
- document branching model and Docker instructions
- configure GitHub Actions workflow to build and deploy image to AWS ECR/ECS

## Testing
- `pytest` *(fails: PyYAML is required to load configuration files)*

------
https://chatgpt.com/codex/tasks/task_e_6890547c3f1c832985dacacd896778a5